### PR TITLE
In MSIE detach the child nodes before render 

### DIFF
--- a/backbone-component.js
+++ b/backbone-component.js
@@ -172,7 +172,7 @@ Backbone.Component = Backbone.View.extend({
       return true;
     }
     // MSIE 11
-    return (!(window.ActiveXObject) && "ActiveXObject" in window);
+    return (!(window.ActiveXObject) && 'ActiveXObject' in window);
   })()
 
 });


### PR DESCRIPTION
Fixes that bug which will empty the children if innerHTML is used in the parent view
