### PR TITLE
Modern mustaches

### DIFF
--- a/backbone-component.js
+++ b/backbone-component.js
@@ -72,7 +72,7 @@
 
     // Render the existing template with the provided data.
     renderTemplate: function(data) {
-      this.$el.html(this._compile(this.template)(data));
+      this.$el.html(this._compile(this.template)(data || {}));
       return this;
     },
 


### PR DESCRIPTION
Compiled templates in modern Mustaches (or, at least 2.1.3) don't like being given non-object contexts
